### PR TITLE
added parethesis to pipeline description to allow for file paths with spaces

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -29,7 +29,7 @@ impl IntoIterator for FileSource {
 
     fn into_iter(self) -> Self::IntoIter {
         let pipeline_description = format!(
-            "uridecodebin uri=file://{} ! videoconvert ! videoscale ! capsfilter caps=\"video/x-raw, width={}, height={}\"",
+            "uridecodebin uri=\"file://{}\" ! videoconvert ! videoscale ! capsfilter caps=\"video/x-raw, width={}, height={}\"",
             self.source.to_string_lossy(),
             self.frame_size.0,
             self.frame_size.1


### PR DESCRIPTION
### Description: 
When FileSource::into_iter() is called with a file path that contains ' ' characters, the gst-parser interprets each word as a new element, which causes an error.

#### Example of an error message (where the second word in the video title is 2022):
thread 'main' panicked at 'Pipeline description invalid, cannot create: Error { domain: gst_parse_error, code: 1, message: "no element \\"2022\\"" }',  vid2img-0.1.1/src/video_stream.rs:59:10

### change:
This change surrounds the file path with parenthesis, thereby avoiding the error.